### PR TITLE
Use resolve() to find which ractive.js to require

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,17 @@
 module.exports = function (source) {
-	var Ractive = require("ractive");
 
-	this.cacheable();
-	return "module.exports=" + JSON.stringify(Ractive.parse(source)) + ";";
+    var callback = this.async();
+
+    this.cacheable();
+
+    this.resolve(this.context, "ractive", function(err, result) {
+
+        if(err) return callback(err);
+
+        var Ractive = require(result);
+        Ractive.DEBUG = false;
+        
+        callback(null, "module.exports=" + JSON.stringify(Ractive.parse(source)) + ";");
+    });
+
 };


### PR DESCRIPTION
This solves two issues.

1) If you have ractive installed globally with `npm i -g`, `ractive-loader` will pick up on that and use it and it may be the wrong version/patch of ractive (took me a long time to figure that one out sadly :( ).

2) This removes the dependency of Ractive having to be in your node_modules folder by adding support for `resolve.alias` and for `resolve.moduleDirectories`.  So now you can do something like:

```
        alias: {
            ractive$: process.cwd() + '/js/lib/ractive.js'
        },
```

And `ractive-loader` will pick up on that and require the correct ractive. This is important so that you have the same version of ractive being used to parse your templates as the version you are running. Since Edge and beta versions aren't on NPM, this makes it work for all cases.
