### PR TITLE
Silence Ractive debug messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 module.exports = function (source) {
 	var Ractive = require("ractive");
-
+ 	Ractive.DEBUG = false;
 	this.cacheable();
 	return "module.exports=" + JSON.stringify(Ractive.parse(source)) + ";";
 };


### PR DESCRIPTION
This silences the debug text that Ractive prints to the console. Prevents messy webpack build terminal output.

Since updating to Ractive 0.8.0, webpack builds are trashed by ractive's debug messages:

```
# building clientside application
node --max-old-space-size=4096 `which webpack` --output-path dist/build -d --watch --progress --color
 42% 28/52 build modules%cRactive.js %c0.8.0 %cin debug mode, %cmore... color: rgb(114, 157, 52); font-weight: normal; color: rgb(85, 85, 85); font-weight: normal; color: rgb(85, 85, 85); font-weight: normal; color: rgb(82, 140, 224); font-weight: normal; text-decoration: underline;
You're running Ractive 0.8.0 in debug mode - messages will be printed to the console to help you fix problems and optimise your application.

To disable debug mode, add this line at the start of your app:
  Ractive.DEBUG = false;

To disable debug mode when your app is minified, add this snippet:
  Ractive.DEBUG = /unminified/.test(function(){/*unminified*/});

Get help and support:
  http://docs.ractivejs.org
  http://stackoverflow.com/questions/tagged/ractivejs
  http://groups.google.com/forum/#!forum/ractive-js
  http://twitter.com/ractivejs

Found a bug? Raise an issue:
  https://github.com/ractivejs/ractive/issues


%cRactive.js: %cUnqualified method events are deprecated. Prefix methods with '@this.' to call methods on the current Ractive instance. color: rgb(114, 157, 52); color: rgb(85, 85, 85);
 59% 373/451 build modules%cRactive.js: %cProxy events with arguments are deprecated. You can fire events with arguments using "@this.fire('eventName', arg1, arg2, ...)". color: rgb(114, 157, 52); color: rgb(85, 85, 85);
```

Ideally this would be an option passed into the loader, but this is a good start.
